### PR TITLE
Use Monotonic clock

### DIFF
--- a/snowflake.go
+++ b/snowflake.go
@@ -100,11 +100,7 @@ func NewNode(node int64) (*Node, error) {
 		return nil, errors.New("Node number must be between 0 and " + strconv.FormatInt(nodeMax, 10))
 	}
 
-	return &Node{
-		// time: 0,
-		node: node,
-		step: 0,
-	}, nil
+	return &Node{node: node}, nil
 }
 
 // Generate creates and returns a unique snowflake ID


### PR DESCRIPTION
Starting from Go 1.9, the standard time package transparently uses Monotonic Clocks when available. Let's use that for generating ids to safeguard against wall clock backwards movement which could be caused by time drifts or leap seconds.

This PR addresses the aforementioned issue which may lead to collisions.